### PR TITLE
fix(be): Swagger로 서버와 api 테스트 할 수 있도록 수정

### DIFF
--- a/backend/src/main/java/com/example/moki_campaign/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/example/moki_campaign/global/config/SwaggerConfig.java
@@ -20,8 +20,8 @@ public class SwaggerConfig {
     public OpenAPI openAPI() {
         return new OpenAPI()
                 .servers(List.of(
-                        new Server().url("http://localhost:8080").description("로컬 서버")
-                        // new Server().url("https://api.moki-campaign.com").description("개발 서버")
+                        new Server().url("http://localhost:8080").description("로컬 서버"),
+                        new Server().url("http://13.209.207.94:8080").description("개발 서버")
                 ))
                 .components(new Components()
                         .addSecuritySchemes("bearerAuth",


### PR DESCRIPTION
## ✨ 요약

swagger로 ec2 서버와 테스트할 수 있도록 로직을 추가했다.

## 🔗 작업 내용

- SwaggerConfig 로직 추가

## 💻 상세 구현 내용

- SwaggerConfig에 Swagger 사용 시 로컬에서만 api 테스트를 할 수 있도록 되어 있었다. 이 부분에 개발 서버를 추가해서 ec2 서버와 api 테스트할 수 있도록 로직을 추가했다.

## 🔗 참고 사항

해당 pr이 머지되면 아래 스크린샷의 Servers에서 새로 개발 서버라는 항목이 추가된다. 이를 선택하면 서버로 api 요청을 보낼 수 있다.

## 📸 스크린샷 (Screenshots)
<img width="1352" height="483" alt="image" src="https://github.com/user-attachments/assets/ee12588e-45ee-4cd0-b5cf-017ce8a7a4c3" />


## 🔗 관련 이슈

- Close #16 
