### PR TITLE
fix: 고객 분석 요청 메서드에 트랜젝션이 걸리도록 수정

### DIFF
--- a/backend/src/main/java/com/example/moki_campaign/domain/customer/service/CustomerServiceImpl.java
+++ b/backend/src/main/java/com/example/moki_campaign/domain/customer/service/CustomerServiceImpl.java
@@ -13,12 +13,11 @@ import com.example.moki_campaign.infra.ai.client.AiClient;
 import com.example.moki_campaign.infra.ai.dto.AiCustomerDataInputDto;
 import com.example.moki_campaign.infra.ai.dto.AiCustomerDataOutputDto;
 import com.example.moki_campaign.infra.ai.dto.AiCustomerDataResponseDto;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.annotation.Propagation;
+import org.springframework.context.annotation.Lazy;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class CustomerServiceImpl implements CustomerService {
 
@@ -37,6 +35,20 @@ public class CustomerServiceImpl implements CustomerService {
     private final DailyVisitRepository dailyVisitRepository;
     private final AiClient aiClient;
 
+    private final CustomerService self;
+
+    public CustomerServiceImpl(
+            StoreRepository storeRepository,
+            CustomerRepository customerRepository,
+            DailyVisitRepository dailyVisitRepository,
+            AiClient aiClient,
+            @Lazy CustomerService self) {
+        this.storeRepository = storeRepository;
+        this.customerRepository = customerRepository;
+        this.dailyVisitRepository = dailyVisitRepository;
+        this.aiClient = aiClient;
+        this.self = self;
+    }
     // 전체 매장의 고객들에 대한 ai 고객 분석
     // 테스트 위해 @Async 추가(테스트 완료하면 테스트 로직 삭제 예정)
     @Async
@@ -57,7 +69,7 @@ public class CustomerServiceImpl implements CustomerService {
 
         for (Store store : stores) {
             try {
-                analyzeStore(store);
+                self.analyzeStore(store);
                 successCount++;
             } catch (Exception e) {
                 log.error("매장({}) AI 분석 실패", store.getName(), e);
@@ -71,7 +83,7 @@ public class CustomerServiceImpl implements CustomerService {
     // 특정 매장의 고객을 대상으로 ai 분석
     // 항상 새로운 트렌젝션을 시작
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void analyzeStore(Store store) {
 
         try {

--- a/backend/src/test/java/com/example/moki_campaign/customer/service/CustomerServiceImplTest.java
+++ b/backend/src/test/java/com/example/moki_campaign/customer/service/CustomerServiceImplTest.java
@@ -12,14 +12,14 @@ import com.example.moki_campaign.infra.ai.client.AiClient;
 import com.example.moki_campaign.infra.ai.dto.AiCustomerDataInputDto;
 import com.example.moki_campaign.infra.ai.dto.AiCustomerDataOutputDto;
 import com.example.moki_campaign.infra.ai.dto.AiCustomerDataResponseDto;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.lang.reflect.Field;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
@@ -27,11 +27,15 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
-class CustomerServiceImplTest {
+public class CustomerServiceImplTest {
 
     @Mock
     private StoreRepository storeRepository;
@@ -42,9 +46,24 @@ class CustomerServiceImplTest {
     @Mock
     private AiClient aiClient;
 
-    @Spy
-    @InjectMocks
     private CustomerServiceImpl customerService;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        CustomerServiceImpl realService = new CustomerServiceImpl(
+                storeRepository,
+                customerRepository,
+                dailyVisitRepository,
+                aiClient,
+                null
+        );
+
+        customerService = spy(realService);
+
+        Field selfField = CustomerServiceImpl.class.getDeclaredField("self");
+        selfField.setAccessible(true);
+        selfField.set(customerService, customerService);
+    }
 
     @Test
     void 여러매장_분석_성공() {


### PR DESCRIPTION
## ✨ 요약

be-ai 간 연결이 정상적으로 이뤄졌으나, 분석 후 데이터를 저장 시 에러가 발생했다.
고객 분석 시 비동기로 여러 쓰레드가 동시에 고객 분석을 요청하는데 이때 트렌젝션이 쓰레드에 적용되지 않아 업데이트 쿼리 시 정상적으로 진행되지 않는 문제가 발생했다. 이를 해결했다. 

## 🔗 작업 내용

- 트렌젝션이 적용되지 않는 문제 해결

## 💻 상세 구현 내용

- 비동기 메서드에서 트렌젝션 호출 시 AOP 프록시를 거치지 않아 트렌젝션이 무시되었다. 이에 자기자신의 프록시 객체를 통해 호출하도록 로직을 변경했다.
## 🔗 참고 사항

머지되고 고객 분석이 정상작동하면 바로 나머지 api 개발할 예정입니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #37 
