### PR TITLE
fix(fe): 로고 사진 호출 경로 수정

### DIFF
--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -5,6 +5,7 @@ import { loginUser, resetStatus } from "../store/authSlice.ts";
 import { type AppDispatch, type RootState } from "../store/index.ts";
 import Input from "../components/common/Input.tsx";
 import Button from "../components/common/Button.tsx";
+import mokiLogo from "../assets/moki_logo.svg";
 
 /**
  * 로그인 페이지 컴포넌트
@@ -69,7 +70,7 @@ const LoginPage: React.FC = () => {
         <div className="flex flex-col items-center justify-center space-y-2 pb-4">
           {/* 이미지 로고: W-200, H-100 크기 스타일을 추가했습니다. */}
           <img
-            src="/src/assets/moki_logo.svg"
+            src={mokiLogo}
             alt="앱 로고"
             className="w-200 h-100"
           />


### PR DESCRIPTION
## ✨ 요약

> 로그인 페이지의 로고 사진 렌더링 문제를 해결한다.

## 🔗 작업 내용

- 현재 로고 사진 호출 경로가 하드코딩으로 작성된 것을 발견했습니다.
- 로고를 상대경로로 호출하여 배포 시 렌더링 오류가 나지 않도록 하였습니다.

## 💻 상세 구현 내용

> 로고 사진 호출 방식을 변경하였습니다. (하드코딩 -> import 를 통한 로고 사진 불러오기)

## 🔗 참고 사항

> 리뷰어가 알아야 할 참고 사항 등을 기록합니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #64
