### PR TITLE
refactor(ai): 이탈위험 기준값을 0.4->0.5로 변경

### DIFF
--- a/ai/src/data/api.py
+++ b/ai/src/data/api.py
@@ -220,7 +220,7 @@ def analyze_customer_data(df: pd.DataFrame) -> pd.DataFrame:
         
         # 4. 세그먼트 할당 (요청하신 임계값 적용)
         LOYALTY_THRESHOLD = 0.60      # 충성도 기준 0.6
-        CHURN_RISK_THRESHOLD = 0.40   # 이탈 기준 0.4
+        CHURN_RISK_THRESHOLD = 0.5    # 이탈 기준 0.5 (수정됨)
 
         df_active["is_loyal"] = df_active["predicted_loyalty_score"] >= LOYALTY_THRESHOLD
         df_active["is_high_risk"] = df_active["churn_risk_score"] >= CHURN_RISK_THRESHOLD


### PR DESCRIPTION
## ✨ 요약

이탈위험 기준값을 0.4->0.5로 변경합니다.

## 🔗 작업 내용

- 이탈위험 기준값을 0.4->0.5로 변경

## 💻 상세 구현 내용

## 🔗 참고 사항

머지 후 분석이 적절히 된 것을 확인하면, 시각화 스크린샷 이 pr에 올리고 문서작업 시작하겠습니다.
적절히 됬다고 판단되지 않으면 0.6으로 상향 후 결과 확인해봐야 할 것 같습니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #76 
