### PR TITLE
refactor(ai): 이탈위험 기준치 0.6으로 조정

### DIFF
--- a/ai/src/data/api.py
+++ b/ai/src/data/api.py
@@ -220,7 +220,7 @@ def analyze_customer_data(df: pd.DataFrame) -> pd.DataFrame:
         
         # 4. 세그먼트 할당 (요청하신 임계값 적용)
         LOYALTY_THRESHOLD = 0.60      # 충성도 기준 0.6
-        CHURN_RISK_THRESHOLD = 0.5    # 이탈 기준 0.5 (수정됨)
+        CHURN_RISK_THRESHOLD = 0.60    # 이탈 기준 0.6 (수정됨)
 
         df_active["is_loyal"] = df_active["predicted_loyalty_score"] >= LOYALTY_THRESHOLD
         df_active["is_high_risk"] = df_active["churn_risk_score"] >= CHURN_RISK_THRESHOLD


### PR DESCRIPTION
## ✨ 요약

이탈위험 기준치 0.6으로 조정

## 🔗 작업 내용

- 이탈위험 기준치 0.6으로 조정

## 💻 상세 구현 내용

> 변경된 내용에 대해 기술적인 설명을 작성합니다. 

## 🔗 참고 사항

아직 적절히 분류하고 있지 않아 0.6으로 상향했습니다.

## 📸 스크린샷 (Screenshots)


## 🔗 관련 이슈

- Close #이슈번호
